### PR TITLE
Fix blank About page

### DIFF
--- a/src/pages/About.tsx
+++ b/src/pages/About.tsx
@@ -11,7 +11,6 @@ const About = () => {
         description="Discover UV Agency's journey in creating innovative media experiences and events. Learn about our team, values, and commitment to excellence."
         pageType="about"
       />
-      return null;
     </div>
   );
 };


### PR DESCRIPTION
## Summary
- remove stray `return null` from `About` page

## Testing
- `npx vitest run`

------
https://chatgpt.com/codex/tasks/task_e_684ad885b13c8329a71af979771958fa