### PR TITLE
Fix memory leak in toast hook

### DIFF
--- a/src/hooks/use-toast.ts
+++ b/src/hooks/use-toast.ts
@@ -179,7 +179,7 @@ function useToast() {
         listeners.splice(index, 1)
       }
     }
-  }, [state])
+  }, [])
 
   return {
     ...state,


### PR DESCRIPTION
## Summary
- prevent listener duplication in `useToast`

## Testing
- `pnpm exec vitest run`

------
https://chatgpt.com/codex/tasks/task_e_684c2bd6429c8329887d67153f35860a