### PR TITLE
Improve responsive layout and viewport units

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -72,13 +72,13 @@ nav {
 /* Body styles when About is open */
 body.about-open {
   overflow: hidden !important;
-  height: 100vh;
+  height: 100dvh;
 }
 
 /* Body styles when Contact is open */
 body.contact-open {
   overflow: hidden !important;
-  height: 100vh;
+  height: 100dvh;
 }
 
 /* Prevent content shift when scrollbar disappears */

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -24,7 +24,7 @@ const queryClient = new QueryClient();
 
 // Loading component
 const LoadingFallback = () => (
-  <div className="min-h-screen flex items-center justify-center bg-background">
+  <div className="min-h-[100dvh] flex items-center justify-center bg-background">
     <div className="text-center">
       <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-primary mx-auto mb-4"></div>
       <p className="text-lg text-muted-foreground">Loading...</p>
@@ -36,7 +36,7 @@ const LoadingFallback = () => (
 const RouteErrorBoundary: React.FC<{ children: React.ReactNode }> = ({ children }) => (
   <ErrorBoundary
     fallback={
-      <div className="min-h-screen flex items-center justify-center bg-background p-4">
+      <div className="min-h-[100dvh] flex items-center justify-center bg-background p-4">
         <div className="text-center">
           <h1 className="text-4xl font-bold mb-4">Page Error</h1>
           <p className="text-xl text-muted-foreground mb-4">

--- a/src/components/ErrorBoundary.tsx
+++ b/src/components/ErrorBoundary.tsx
@@ -55,7 +55,7 @@ class ErrorBoundary extends Component<Props, State> {
       }
 
       return (
-        <div className="min-h-screen flex items-center justify-center bg-background p-4">
+        <div className="min-h-[100dvh] flex items-center justify-center bg-background p-4">
           <Alert variant="destructive" className="max-w-2xl">
             <AlertTitle>Something went wrong</AlertTitle>
             <AlertDescription className="mt-2">

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -56,8 +56,8 @@ const Navbar = () => {
       {/* Info Section */}
       <div 
         className="w-full bg-[#283618] transition-all duration-500 ease-in-out hideScrollbar"
-        style={{ 
-          height: isInfoOpen ? '100vh' : '0',
+        style={{
+          height: isInfoOpen ? '100dvh' : '0',
           opacity: isInfoOpen ? 1 : 0,
           overflowY: isInfoOpen ? 'scroll' : 'hidden'
         }}
@@ -72,8 +72,8 @@ const Navbar = () => {
       {/* Contact Section */}
       <div 
         className={`fixed bottom-0 left-0 w-full bg-portfolio-about-bg overflow-hidden z-${NAVBAR_CONSTANTS.Z_INDEX.CONTACT_SECTION} transition-all ${isContactOpen ? 'duration-500' : 'duration-300'}`}
-        style={{ 
-          height: isContactOpen ? '80vh' : '0',
+        style={{
+          height: isContactOpen ? '80dvh' : '0',
           transform: `translateY(${isContactOpen ? '0' : '100%'})`,
           opacity: 1
         }}

--- a/src/components/project/ProjectHeader.tsx
+++ b/src/components/project/ProjectHeader.tsx
@@ -31,24 +31,24 @@ const ProjectHeader: React.FC<ProjectHeaderProps> = ({ project }) => {
     <div className="max-w-[90%] mx-auto">
       <div className="border-b border-portfolio-divider pb-6 mb-8">
         <div className="w-full flex flex-col items-center md:items-start">
-          <div className="inline-flex flex-wrap items-center gap-4">
+          <div className="inline-flex flex-wrap items-center gap-2 md:gap-4">
             <button 
               onClick={handleClose}
               className="w-10 h-10 rounded-full bg-transparent border border-portfolio-text flex items-center justify-center text-portfolio-text hover:bg-portfolio-text hover:text-portfolio-bg transition-colors"
             >
               <X size={18} />
             </button>
-            <h1 className="text-7xl font-bold text-portfolio-text">{project.name}</h1>
-            <span className="project-year-tag text-base px-6 py-2 rounded-full bg-portfolio-tag-bg text-portfolio-tag-text">
+            <h1 className="text-4xl md:text-7xl font-bold text-portfolio-text">{project.name}</h1>
+            <span className="project-year-tag text-sm md:text-base px-4 md:px-6 py-1 md:py-2 rounded-full bg-portfolio-tag-bg text-portfolio-tag-text">
               {project.year}
             </span>
             {project.categories.map((category) => (
-              <span key={category} className="project-category-tag text-base px-6 py-2 border rounded-full">
+              <span key={category} className="project-category-tag text-sm md:text-base px-4 md:px-6 py-1 md:py-2 border rounded-full">
                 {category}
               </span>
             ))}
             {project.comingSoon && (
-              <span className="project-coming-soon-tag text-base px-6 py-2 border rounded-full bg-portfolio-highlight text-portfolio-bg">
+              <span className="project-coming-soon-tag text-sm md:text-base px-4 md:px-6 py-1 md:py-2 border rounded-full bg-portfolio-highlight text-portfolio-bg">
                 COMING SOOOOOON
               </span>
             )}

--- a/src/pages/About.tsx
+++ b/src/pages/About.tsx
@@ -5,7 +5,7 @@ const About = () => {
   // About page content is now handled by the panel in the Navbar
   // This component is kept for compatibility with existing routes
   return (
-    <div className="min-h-screen bg-portfolio-bg">
+    <div className="min-h-[100dvh] bg-portfolio-bg">
       <SEO 
         title="About UV Agency | Creative Media Experiences"
         description="Discover UV Agency's journey in creating innovative media experiences and events. Learn about our team, values, and commitment to excellence."

--- a/src/pages/Contact.tsx
+++ b/src/pages/Contact.tsx
@@ -3,7 +3,7 @@ import { SEO } from '../components/SEO';
 
 const Contact = () => {
   return (
-    <div className="min-h-screen bg-portfolio-bg">
+    <div className="min-h-[100dvh] bg-portfolio-bg">
       <SEO 
         title="Contact UV Agency | Get in Touch"
         description="Get in touch with UV Agency for your next media experience project. We're here to help bring your creative vision to life."

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -6,7 +6,7 @@ import Footer from "../components/Footer";
 
 const Index = () => {
   return (
-    <div className="min-h-screen bg-portfolio-bg">
+    <div className="min-h-[100dvh] bg-portfolio-bg">
       <div className="main-content">
         <Hero />
         <BrandCarousel />

--- a/src/pages/NotFound.tsx
+++ b/src/pages/NotFound.tsx
@@ -12,7 +12,7 @@ const NotFound = () => {
   }, [location.pathname]);
 
   return (
-    <div className="min-h-screen flex items-center justify-center bg-gray-100">
+    <div className="min-h-[100dvh] flex items-center justify-center bg-gray-100">
       <div className="text-center">
         <h1 className="text-4xl font-bold mb-4">404</h1>
         <p className="text-xl text-gray-600 mb-4">Oops! Page not found</p>

--- a/src/pages/OurCompany.tsx
+++ b/src/pages/OurCompany.tsx
@@ -82,7 +82,7 @@ const OurCompany = () => {
   
 
   return (
-    <div className="min-h-screen bg-portfolio-bg">
+    <div className="min-h-[100dvh] bg-portfolio-bg">
       <SEO 
         title="Our Company | UV Agency"
         description="Learn about UV Agency's mission, values, and the team behind our innovative media experiences. Discover how we're shaping the future of creative events."

--- a/src/pages/ProjectDetail.tsx
+++ b/src/pages/ProjectDetail.tsx
@@ -73,7 +73,7 @@ const ProjectDetail = () => {
   }
 
   return (
-    <div className="min-h-screen bg-portfolio-bg">
+    <div className="min-h-[100dvh] bg-portfolio-bg">
       <SEO 
         title={`${project.name} | UV Agency`}
         description={project.description}
@@ -85,10 +85,10 @@ const ProjectDetail = () => {
         }}
       />
       <div className="fixed inset-0 z-50 bg-portfolio-bg overflow-y-auto">
-        <div className="w-full mx-auto pt-8 pb-16">
+        <div className="w-full mx-auto pt-8 pb-16 md:pt-12 md:pb-24 px-4 sm:px-8">
           <ProjectHeader project={project} />
 
-          <div className="max-w-[90%] mx-auto">
+          <div className="max-w-[95%] md:max-w-[90%] lg:max-w-5xl mx-auto">
             {/* Video Section */}
             {project.videoUrl && (
               <Suspense fallback={<SectionLoading />}>

--- a/src/pages/UnitedMedia.tsx
+++ b/src/pages/UnitedMedia.tsx
@@ -54,7 +54,7 @@ const UnitedMedia = () => {
   ];
   
   return (
-    <div className="min-h-screen bg-portfolio-bg">
+    <div className="min-h-[100dvh] bg-portfolio-bg">
       <SEO 
         title="United Media @ UV Agency"
         description="Learn about UV Agency's United Media service, designed to connect brands with people in a phygital world."

--- a/src/styles/animations.css
+++ b/src/styles/animations.css
@@ -114,14 +114,14 @@
     opacity: 0;
   }
   to {
-    max-height: calc(100vh - 77px);
+    max-height: calc(100dvh - 77px);
     opacity: 1;
   }
 }
 
 @keyframes slideUpOut {
   from {
-    max-height: calc(100vh - 77px);
+    max-height: calc(100dvh - 77px);
     opacity: 1;
   }
   to {


### PR DESCRIPTION
## Summary
- tweak ProjectHeader heading and tags for responsive sizes
- adjust ProjectDetail layout spacing and widths
- use `100dvh` for viewport-based heights
- update pages and components to use `min-h-[100dvh]`

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684c2e9df5ec83299154751f733844dd