### PR TITLE
Fix GA params

### DIFF
--- a/src/lib/analytics.ts
+++ b/src/lib/analytics.ts
@@ -33,6 +33,8 @@ export const GA_PARAMS = {
   // Project parameters
   PROJECT_ID: 'project_id',
   PROJECT_NAME: 'project_name',
+  PROJECT_CATEGORY: 'project_category',
+  PROJECT_CLIENT: 'project_client',
   
   // Video parameters
   VIDEO_ID: 'video_id',


### PR DESCRIPTION
## Summary
- add missing GA params for project category and client

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6856c373f0c083298eacf414b5ca8b72