### PR TITLE
Remove duplicate font rules

### DIFF
--- a/src/styles/base.css
+++ b/src/styles/base.css
@@ -81,13 +81,6 @@
     --ring: 222.2 84% 4.9%;
   }
 
-  /* Ensure font is applied to all elements */
-  :root,
-  *,
-  *::before,
-  *::after {
-    font-family: 'Open Sans' !important;
-  }
 
   * {
     @apply border-border;


### PR DESCRIPTION
## Summary
- delete font-family styles from `base.css` and rely on `fonts.css`

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6856c6774688832984c2c7f0b61894d2