### PR TITLE
Fix tailwind content paths

### DIFF
--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -2,12 +2,10 @@ import type { Config } from "tailwindcss";
 
 export default {
 	darkMode: ["class"],
-	content: [
-		"./pages/**/*.{ts,tsx}",
-		"./components/**/*.{ts,tsx}",
-		"./app/**/*.{ts,tsx}",
-		"./src/**/*.{ts,tsx}",
-	],
+       content: [
+               "./index.html",
+               "./src/**/*.{ts,tsx}",
+       ],
 	prefix: "",
 	theme: {
 		fontFamily: {


### PR DESCRIPTION
## Summary
- keep only existing folders in tailwind `content`

## Testing
- `pnpm lint` *(fails: @typescript-eslint/no-empty-object-type, @typescript-eslint/no-require-imports)*
- `pnpm exec vitest run`

------
https://chatgpt.com/codex/tasks/task_e_6856c68d5ac883298e1e317fa46436d0