### PR TITLE
Fix cross-origin headers so Vimeo and images load

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -18,8 +18,10 @@
     Permissions-Policy = "camera=(), microphone=(), geolocation=()"
     Strict-Transport-Security = "max-age=31536000; includeSubDomains"
     Cross-Origin-Opener-Policy = "same-origin"
-    Cross-Origin-Embedder-Policy = "require-corp"
-    Cross-Origin-Resource-Policy = "same-origin"
+    # Removing strict cross-origin policies to allow external media
+    # These headers prevented Vimeo videos and external images from loading
+    # Cross-Origin-Embedder-Policy = "require-corp"
+    # Cross-Origin-Resource-Policy = "same-origin"
     Access-Control-Allow-Origin = "*"
     Access-Control-Allow-Methods = "GET, POST, PUT, DELETE, OPTIONS"
     Access-Control-Allow-Headers = "Content-Type, Authorization"


### PR DESCRIPTION
## Summary
- disable strict cross-origin policies in `netlify.toml` to let external images and Vimeo videos load

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6859b475e7a08329ae210cc5c43bd1bc