### PR TITLE
Update job listings with new positions and application links

### DIFF
--- a/src/data/jobsData.ts
+++ b/src/data/jobsData.ts
@@ -10,66 +10,66 @@ export interface Job {
 export const jobsData: Job[] = [
     {
         id: "account-executive",
-        title: "EJECUTIVO/A CUENTAS",
+        title: "EJECUTIVO/A DE CUENTAS",
         type: "Full-time",
-        location: "On-site",
+        location: "Hybrid",
         description: "Serve as the primary liaison between clients and our creative teams. Build lasting relationships and ensure exceptional project delivery.",
-        applyUrl: "https://forms.gle/6f6xoN5V8skwspye8"
+        applyUrl: "https://forms.gle/bGtZk5bAE5XFAZzD7"
     },
     {
         id: "designer",
         title: "DISEÑADOR/A",
-        type: "Full-time",
+        type: "Full-time / Part-time",
         location: "Hybrid",
         description: "Create visual concepts that inspire, inform, and captivate consumers. Develop the overall layout and production design for various applications.",
-        applyUrl: "https://forms.gle/oUEGh5qxtjYDVmWc8"
+        applyUrl: "https://forms.gle/Qpq7VxTzss2yQGLb7"
     },
     {
         id: "media-planner",
         title: "MEDIA PLANNER",
-        type: "Full-time",
+        type: "Full-time / Part-time",
         location: "Hybrid",
         description: "Identify which media platforms would best advertise a client's brand or product. Maximize the impact of advertising campaigns through strategic planning.",
-        applyUrl: "https://forms.gle/k12SXvHDpZF2jQmA7"
-    },
-    {
-        id: "community-manager",
-        title: "COMMUNITY MANAGER",
-        type: "Full-time",
-        location: "Hybrid",
-        description: "Build and manage our online communities. Engage with audiences, moderate discussions, and represent the brand across social channels.",
-        applyUrl: "mailto:jobs@uv.agency?subject=Job Application - Community Manager"
+        applyUrl: "https://forms.gle/kAXFumdP5rrgCr7F9"
     },
     {
         id: "copywriter",
         title: "REDACTOR",
-        type: "Full-time",
-        location: "Remote",
+        type: "Full-time / Part-time",
+        location: "Hybrid",
         description: "Craft compelling copy that tells stories and drives action. Experience writing for multicultural audiences in multiple languages is highly valued.",
-        applyUrl: "https://forms.gle/3XuAu957YrVMeHLR7"
+        applyUrl: "https://forms.gle/nTqtJENXxxeVbkBU9"
     },
     {
-        id: "influencer-manager",
-        title: "INFLUENCER MANAGER",
-        type: "Full-time",
+        id: "senior-art-director",
+        title: "DIRECTORA DE ARTE SENIOR",
+        type: "Full-time / Part-time",
         location: "Hybrid",
-        description: "Lead influencer outreach, campaign strategy, and relationship management to drive brand awareness and engagement across social platforms.",
-        applyUrl: "mailto:jobs@uv.agency?subject=Job Application - Influencer Manager"
+        description: "Lead the visual direction of campaigns and projects. Define creative standards and mentor the design team to deliver exceptional brand experiences.",
+        applyUrl: "https://forms.gle/3io9JrjjtW1HrFGH7"
     },
     {
-        id: "event-producer",
-        title: "PRODUCTOR EVENTOS",
-        type: "Full-time",
-        location: "On-site",
-        description: "Design and execute immersive brand experiences and events. From concept to completion, you'll create moments that move people to become customers.",
-        applyUrl: "mailto:jobs@uv.agency?subject=Job Application - Event Producer"
-    },
-    {
-        id: "content-creator",
-        title: "CONTENT CREATOR",
-        type: "Full-time",
+        id: "digital-content-editor",
+        title: "EDITOR CONTENIDO DIGITAL",
+        type: "Full-time / Part-time",
         location: "Hybrid",
-        description: "Develop engaging content for various platforms. Collaborate with the creative team to produce high-quality visual and written material.",
-        applyUrl: "https://forms.gle/48WLRDHjtKup4WLi8"
+        description: "Edit and produce digital content across platforms. Ensure quality, consistency, and brand alignment in every piece of visual and written content.",
+        applyUrl: "https://forms.gle/iFLP9D68AE5nn49E8"
+    },
+    {
+        id: "content-creator-chile",
+        title: "CONTENT CREATOR CHILE",
+        type: "Contract",
+        location: "Hybrid",
+        description: "Create engaging content tailored for the Chilean market. Produce high-quality visual and written material that resonates with local audiences.",
+        applyUrl: "https://forms.gle/cLA1Lz2h59iu3WPQ7"
+    },
+    {
+        id: "design-intern",
+        title: "PRÁCTICA DISEÑADOR/A",
+        type: "Internship",
+        location: "Hybrid",
+        description: "Join our design team as an intern and grow your skills in a real agency environment. Work alongside senior designers on live projects for top brands.",
+        applyUrl: "https://forms.gle/neKsLtPKmrUeNRyj8"
     }
 ];

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -251,43 +251,43 @@
         "listings": {
             "account-executive": {
                 "type": "Full-time",
-                "location": "On-site",
+                "location": "Hybrid",
                 "description": "Serve as the primary liaison between clients and our creative teams. Build lasting relationships and ensure exceptional project delivery."
             },
             "designer": {
-                "type": "Full-time",
+                "type": "Full-time / Part-time",
                 "location": "Hybrid",
                 "description": "Transforms concepts into powerful visual identities. Designs pieces that don't just look good but communicate with purpose and strategy."
             },
             "media-planner": {
-                "type": "Full-time",
+                "type": "Full-time / Part-time",
                 "location": "Hybrid",
                 "description": "The reach strategist. Optimizes budgets and selects the ideal channels to ensure the message hits the right audience at the perfect moment."
             },
-            "community-manager": {
-                "type": "Full-time",
-                "location": "Hybrid",
-                "description": "The brand's digital voice. Builds communities, manages reputation, and sparks real conversations that connect the brand with its audience."
-            },
             "copywriter": {
-                "type": "Full-time",
-                "location": "Remote",
+                "type": "Full-time / Part-time",
+                "location": "Hybrid",
                 "description": "Craft compelling copy that tells stories and drives action. Experience writing for multicultural audiences in multiple languages is highly valued."
             },
-            "influencer-manager": {
-                "type": "Full-time",
+            "senior-art-director": {
+                "type": "Full-time / Part-time",
                 "location": "Hybrid",
-                "description": "Connects brands with authentic creators. Manages strategic partnerships that amplify the message organically with measurable results."
+                "description": "Lead the visual direction of campaigns and projects. Define creative standards and mentor the design team to deliver exceptional brand experiences."
             },
-            "event-producer": {
-                "type": "Full-time",
-                "location": "On-site",
-                "description": "Design and execute immersive brand experiences and events. From concept to completion, you'll create moments that move people to become customers."
-            },
-            "content-creator": {
-                "type": "Full-time",
+            "digital-content-editor": {
+                "type": "Full-time / Part-time",
                 "location": "Hybrid",
-                "description": "Develop engaging content for various platforms. Collaborate with the creative team to produce high-quality visual and written material."
+                "description": "Edit and produce digital content across platforms. Ensure quality, consistency, and brand alignment in every piece of visual and written content."
+            },
+            "content-creator-chile": {
+                "type": "Contract",
+                "location": "Hybrid",
+                "description": "Create engaging content tailored for the Chilean market. Produce high-quality visual and written material that resonates with local audiences."
+            },
+            "design-intern": {
+                "type": "Internship",
+                "location": "Hybrid",
+                "description": "Join our design team as an intern and grow your skills in a real agency environment. Work alongside senior designers on live projects for top brands."
             }
         }
     },

--- a/src/locales/es/translation.json
+++ b/src/locales/es/translation.json
@@ -251,43 +251,43 @@
         "listings": {
             "account-executive": {
                 "type": "Tiempo completo",
-                "location": "En el lugar",
+                "location": "Híbrido",
                 "description": "Actúa como el enlace principal entre los clientes y nuestros equipos creativos. Construye relaciones duraderas y garantiza una entrega excepcional del proyecto."
             },
             "designer": {
-                "type": "Tiempo completo",
+                "type": "Tiempo completo / Medio tiempo",
                 "location": "Híbrido",
                 "description": "Transforma conceptos en identidades visuales potentes. Diseña piezas que no solo se ven bien, sino que comunican con propósito y estrategia."
             },
             "media-planner": {
-                "type": "Tiempo completo",
+                "type": "Tiempo completo / Medio tiempo",
                 "location": "Híbrido",
                 "description": "El estratega del alcance. Optimiza presupuestos y selecciona los canales ideales para que el mensaje llegue al público correcto en el momento exacto."
             },
-            "community-manager": {
-                "type": "Tiempo completo",
-                "location": "Híbrido",
-                "description": "La voz digital de la marca. Construye comunidades, gestiona la reputación y genera conversaciones reales que conectan a la marca con su audiencia."
-            },
             "copywriter": {
-                "type": "Tiempo completo",
-                "location": "Remoto",
+                "type": "Tiempo completo / Medio tiempo",
+                "location": "Híbrido",
                 "description": "Redacta textos persuasivos que cuenten historias e impulsen la acción. Se valora mucho la experiencia escribiendo para audiencias multiculturales en varios idiomas."
             },
-            "influencer-manager": {
-                "type": "Tiempo completo",
+            "senior-art-director": {
+                "type": "Tiempo completo / Medio tiempo",
                 "location": "Híbrido",
-                "description": "Conecta marcas con creadores auténticos. Gestiona alianzas estratégicas que amplifican el mensaje de forma orgánica y con resultados medibles."
+                "description": "Lidera la dirección visual de campañas y proyectos. Define estándares creativos y guía al equipo de diseño para entregar experiencias de marca excepcionales."
             },
-            "event-producer": {
-                "type": "Tiempo completo",
-                "location": "En el lugar",
-                "description": "Diseña y ejecuta experiencias de marca y eventos inmersivos. Desde el concepto hasta la finalización, crearás momentos que muevan a las personas a convertirse en clientes."
-            },
-            "content-creator": {
-                "type": "Tiempo completo",
+            "digital-content-editor": {
+                "type": "Tiempo completo / Medio tiempo",
                 "location": "Híbrido",
-                "description": "Desarrolla contenido atractivo para diversas plataformas. Colabora con el equipo creativo para producir material visual y escrito de alta calidad."
+                "description": "Edita y produce contenido digital para múltiples plataformas. Asegura calidad, consistencia y alineación de marca en cada pieza de contenido visual y escrito."
+            },
+            "content-creator-chile": {
+                "type": "Contrato",
+                "location": "Híbrido",
+                "description": "Crea contenido atractivo adaptado al mercado chileno. Produce material visual y escrito de alta calidad que conecta con audiencias locales."
+            },
+            "design-intern": {
+                "type": "Práctica",
+                "location": "Híbrido",
+                "description": "Únete a nuestro equipo de diseño como practicante y desarrolla tus habilidades en un entorno real de agencia. Trabaja junto a diseñadores senior en proyectos reales para grandes marcas."
             }
         }
     },


### PR DESCRIPTION
## Summary
Updated the careers job listings with new positions, modified employment types, and refreshed application form URLs. Removed outdated roles and added new opportunities including a design internship and Chile-specific content creator position.

## Key Changes

**Job Listings Restructuring:**
- Removed: Community Manager, Influencer Manager, Event Producer
- Added: Senior Art Director, Digital Content Editor, Content Creator (Chile), Design Intern
- Updated Account Executive title from "EJECUTIVO/A CUENTAS" to "EJECUTIVO/A DE CUENTAS"

**Employment Type Updates:**
- Designer: Changed from "Full-time" to "Full-time / Part-time"
- Media Planner: Changed from "Full-time" to "Full-time / Part-time"
- Copywriter: Changed from "Full-time" to "Full-time / Part-time"
- Senior Art Director: Set as "Full-time / Part-time"
- Digital Content Editor: Set as "Full-time / Part-time"
- Content Creator (Chile): Set as "Contract"
- Design Intern: Set as "Internship"

**Location Updates:**
- Account Executive: Changed from "On-site" to "Hybrid"
- Copywriter: Changed from "Remote" to "Hybrid"

**Application Links:**
- Updated all Google Forms URLs for existing positions
- Added new Google Forms URLs for new positions

**Localization:**
- Updated both English (`src/locales/en/translation.json`) and Spanish (`src/locales/es/translation.json`) translation files
- Maintained consistency across all job listing descriptions and metadata

## Implementation Details
- All changes maintain the existing Job interface structure
- Job IDs updated to reflect new positions (e.g., `content-creator` → `content-creator-chile`)
- Descriptions updated to accurately reflect role responsibilities
- Translations provided for all new and modified positions in both languages

https://claude.ai/code/session_019NXvbd1VEmwo8r6QuFhbSZ