### PR TITLE
Update: job listings with new positions and form links

### DIFF
--- a/src/data/jobsData.ts
+++ b/src/data/jobsData.ts
@@ -10,7 +10,7 @@ export interface Job {
 export const jobsData: Job[] = [
     {
         id: "account-executive",
-        title: "EJECUTIVO/A DE CUENTAS",
+        title: "EJECUTIVO DE CUENTAS",
         type: "Full-time",
         location: "Hybrid",
         description: "Serve as the primary liaison between clients and our creative teams. Build lasting relationships and ensure exceptional project delivery.",
@@ -18,7 +18,7 @@ export const jobsData: Job[] = [
     },
     {
         id: "designer",
-        title: "DISEÑADOR/A",
+        title: "DISEÑO",
         type: "Full-time / Part-time",
         location: "Hybrid",
         description: "Create visual concepts that inspire, inform, and captivate consumers. Develop the overall layout and production design for various applications.",
@@ -42,7 +42,7 @@ export const jobsData: Job[] = [
     },
     {
         id: "senior-art-director",
-        title: "DIRECTORA DE ARTE SENIOR",
+        title: "DIRECCIÓN DE ARTE SENIOR",
         type: "Full-time / Part-time",
         location: "Hybrid",
         description: "Lead the visual direction of campaigns and projects. Define creative standards and mentor the design team to deliver exceptional brand experiences.",
@@ -66,7 +66,7 @@ export const jobsData: Job[] = [
     },
     {
         id: "design-intern",
-        title: "PRÁCTICA DISEÑADOR/A",
+        title: "PRÁCTICA DISEÑO",
         type: "Internship",
         location: "Hybrid",
         description: "Join our design team as an intern and grow your skills in a real agency environment. Work alongside senior designers on live projects for top brands.",


### PR DESCRIPTION
## Summary
- Replaced job listings with 8 updated positions and new Google Form links
- Removed: Community Manager, Influencer Manager, Productor Eventos, Content Creator
- Added: Dirección de Arte Senior, Editor Contenido Digital, Content Creator Chile, Práctica Diseño
- Updated form URLs for existing positions (Ejecutivo de Cuentas, Diseño, Media Planner, Redactor)
- Used gender-neutral job titles across the board
- Updated translations in both English and Spanish (EN/ES)

## Test plan
- [ ] Verify /jobs page loads correctly
- [ ] Confirm all 8 positions display with correct titles and descriptions
- [ ] Test each "Apply Now" button opens the correct Google Form
- [ ] Check both language versions (EN/ES) show correct translations
- [ ] Verify responsive layout on mobile and desktop

https://claude.ai/code/session_019NXvbd1VEmwo8r6QuFhbSZ

---
_Generated by [Claude Code](https://claude.ai/code/session_019NXvbd1VEmwo8r6QuFhbSZ)_