### PR TITLE
Update: job listings, form links, and i18n titles

### DIFF
--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -250,41 +250,49 @@
         ],
         "listings": {
             "account-executive": {
+                "title": "ACCOUNT EXECUTIVE",
                 "type": "Full-time",
                 "location": "Hybrid",
                 "description": "Serve as the primary liaison between clients and our creative teams. Build lasting relationships and ensure exceptional project delivery."
             },
             "designer": {
+                "title": "DESIGN",
                 "type": "Full-time / Part-time",
                 "location": "Hybrid",
                 "description": "Transforms concepts into powerful visual identities. Designs pieces that don't just look good but communicate with purpose and strategy."
             },
             "media-planner": {
+                "title": "MEDIA PLANNER",
                 "type": "Full-time / Part-time",
                 "location": "Hybrid",
                 "description": "The reach strategist. Optimizes budgets and selects the ideal channels to ensure the message hits the right audience at the perfect moment."
             },
             "copywriter": {
+                "title": "COPYWRITER",
                 "type": "Full-time / Part-time",
                 "location": "Hybrid",
                 "description": "Craft compelling copy that tells stories and drives action. Experience writing for multicultural audiences in multiple languages is highly valued."
             },
             "senior-art-director": {
+                "title": "SENIOR ART DIRECTION",
                 "type": "Full-time / Part-time",
                 "location": "Hybrid",
                 "description": "Lead the visual direction of campaigns and projects. Define creative standards and mentor the design team to deliver exceptional brand experiences."
             },
             "digital-content-editor": {
+                "title": "DIGITAL CONTENT EDITOR",
                 "type": "Full-time / Part-time",
                 "location": "Hybrid",
                 "description": "Edit and produce digital content across platforms. Ensure quality, consistency, and brand alignment in every piece of visual and written content."
             },
             "content-creator-chile": {
+                "title": "CONTENT CREATOR CHILE",
                 "type": "Contract",
                 "location": "Hybrid",
                 "description": "Create engaging content tailored for the Chilean market. Produce high-quality visual and written material that resonates with local audiences."
             },
             "design-intern": {
+                "title": "DESIGN INTERNSHIP",
                 "type": "Internship",
                 "location": "Hybrid",
                 "description": "Join our design team as an intern and grow your skills in a real agency environment. Work alongside senior designers on live projects for top brands."

--- a/src/locales/es/translation.json
+++ b/src/locales/es/translation.json
@@ -250,41 +250,49 @@
         ],
         "listings": {
             "account-executive": {
+                "title": "EJECUTIVO DE CUENTAS",
                 "type": "Tiempo completo",
                 "location": "Híbrido",
                 "description": "Actúa como el enlace principal entre los clientes y nuestros equipos creativos. Construye relaciones duraderas y garantiza una entrega excepcional del proyecto."
             },
             "designer": {
+                "title": "DISEÑO",
                 "type": "Tiempo completo / Medio tiempo",
                 "location": "Híbrido",
                 "description": "Transforma conceptos en identidades visuales potentes. Diseña piezas que no solo se ven bien, sino que comunican con propósito y estrategia."
             },
             "media-planner": {
+                "title": "MEDIA PLANNER",
                 "type": "Tiempo completo / Medio tiempo",
                 "location": "Híbrido",
                 "description": "El estratega del alcance. Optimiza presupuestos y selecciona los canales ideales para que el mensaje llegue al público correcto en el momento exacto."
             },
             "copywriter": {
+                "title": "REDACTOR",
                 "type": "Tiempo completo / Medio tiempo",
                 "location": "Híbrido",
                 "description": "Redacta textos persuasivos que cuenten historias e impulsen la acción. Se valora mucho la experiencia escribiendo para audiencias multiculturales en varios idiomas."
             },
             "senior-art-director": {
+                "title": "DIRECCIÓN DE ARTE SENIOR",
                 "type": "Tiempo completo / Medio tiempo",
                 "location": "Híbrido",
                 "description": "Lidera la dirección visual de campañas y proyectos. Define estándares creativos y guía al equipo de diseño para entregar experiencias de marca excepcionales."
             },
             "digital-content-editor": {
+                "title": "EDITOR CONTENIDO DIGITAL",
                 "type": "Tiempo completo / Medio tiempo",
                 "location": "Híbrido",
                 "description": "Edita y produce contenido digital para múltiples plataformas. Asegura calidad, consistencia y alineación de marca en cada pieza de contenido visual y escrito."
             },
             "content-creator-chile": {
+                "title": "CONTENT CREATOR CHILE",
                 "type": "Contrato",
                 "location": "Híbrido",
                 "description": "Crea contenido atractivo adaptado al mercado chileno. Produce material visual y escrito de alta calidad que conecta con audiencias locales."
             },
             "design-intern": {
+                "title": "PRÁCTICA DISEÑO",
                 "type": "Práctica",
                 "location": "Híbrido",
                 "description": "Únete a nuestro equipo de diseño como practicante y desarrolla tus habilidades en un entorno real de agencia. Trabaja junto a diseñadores senior en proyectos reales para grandes marcas."

--- a/src/pages/Jobs.tsx
+++ b/src/pages/Jobs.tsx
@@ -107,7 +107,7 @@ const Jobs = () => {
                                     <InteractiveTilt key={job.id} className="rounded-xl">
                                         <div className="bg-portfolio-bg/80 border border-portfolio-divider rounded-lg p-6 sm:p-8 shadow-md h-full flex flex-col group hover:border-portfolio-highlight transition-colors overflow-hidden">
                                             <h3 className="text-2xl sm:text-3xl font-bold text-portfolio-text mb-3 group-hover:text-portfolio-highlight transition-colors">
-                                                {job.title}
+                                                {t(`jobs.listings.${job.id}.title`, job.title)}
                                             </h3>
 
                                             <div className="flex flex-wrap gap-2 mb-4">


### PR DESCRIPTION
## Summary
- Replaced job listings with 8 updated positions and new Google Form links
- Removed: Community Manager, Influencer Manager, Productor Eventos, Content Creator
- Added: Dirección de Arte Senior, Editor Contenido Digital, Content Creator Chile, Práctica Diseño
- Used gender-neutral job titles (e.g. Diseño instead of Diseñador/a, Dirección de Arte instead of Directora de Arte)
- Fixed job titles not being translated: now uses i18n so EN and ES each show proper titles
- Updated translations in both English and Spanish

## Test plan
- [ ] Verify /jobs page loads correctly in both EN and ES
- [ ] Confirm all 8 positions display with correct translated titles per language
- [ ] Test each "Apply Now" button opens the correct Google Form
- [ ] Check type/location tags render correctly in both languages
- [ ] Verify responsive layout on mobile and desktop

https://claude.ai/code/session_019NXvbd1VEmwo8r6QuFhbSZ

---
_Generated by [Claude Code](https://claude.ai/code/session_019NXvbd1VEmwo8r6QuFhbSZ)_