### PR TITLE
Add three new job listings (Social Media Manager, Community Manager, Content Intern)

### DIFF
--- a/src/data/jobsData.ts
+++ b/src/data/jobsData.ts
@@ -9,6 +9,30 @@ export interface Job {
 
 export const jobsData: Job[] = [
     {
+        id: "social-media-manager",
+        title: "SOCIAL MEDIA MANAGER",
+        type: "Full-time / Part-time",
+        location: "Hybrid",
+        description: "Lead the strategy, planning, and performance of our clients' social channels. Turn insights into content calendars that grow communities and deliver measurable results.",
+        applyUrl: "https://forms.gle/J7DqKBgCVMxdZqTn9"
+    },
+    {
+        id: "community-manager",
+        title: "COMMUNITY MANAGER",
+        type: "Full-time / Part-time",
+        location: "Hybrid",
+        description: "Be the voice of brands across social platforms. Engage, moderate, and spark genuine conversations that strengthen the bond between brands and their audiences.",
+        applyUrl: "https://forms.gle/PifrG39CNXERZXXW7"
+    },
+    {
+        id: "content-creation-intern-chile",
+        title: "PRÁCTICA CREACIÓN DE CONTENIDO CHILE",
+        type: "Internship",
+        location: "Hybrid",
+        description: "Kick-start your career creating content for real brands in the Chilean market. Learn alongside our creative team while producing visual and written pieces for live campaigns.",
+        applyUrl: "https://forms.gle/3sxBmXE9mZs1pZfk7"
+    },
+    {
         id: "account-executive",
         title: "EJECUTIVO DE CUENTAS",
         type: "Full-time",

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -249,6 +249,24 @@
             }
         ],
         "listings": {
+            "social-media-manager": {
+                "title": "SOCIAL MEDIA MANAGER",
+                "type": "Full-time / Part-time",
+                "location": "Hybrid",
+                "description": "Lead the strategy, planning, and performance of our clients' social channels. Turn insights into content calendars that grow communities and deliver measurable results."
+            },
+            "community-manager": {
+                "title": "COMMUNITY MANAGER",
+                "type": "Full-time / Part-time",
+                "location": "Hybrid",
+                "description": "Be the voice of brands across social platforms. Engage, moderate, and spark genuine conversations that strengthen the bond between brands and their audiences."
+            },
+            "content-creation-intern-chile": {
+                "title": "CONTENT CREATION INTERNSHIP CHILE",
+                "type": "Internship",
+                "location": "Hybrid",
+                "description": "Kick-start your career creating content for real brands in the Chilean market. Learn alongside our creative team while producing visual and written pieces for live campaigns."
+            },
             "account-executive": {
                 "title": "ACCOUNT EXECUTIVE",
                 "type": "Full-time",

--- a/src/locales/es/translation.json
+++ b/src/locales/es/translation.json
@@ -249,6 +249,24 @@
             }
         ],
         "listings": {
+            "social-media-manager": {
+                "title": "SOCIAL MEDIA MANAGER",
+                "type": "Tiempo completo / Medio tiempo",
+                "location": "Híbrido",
+                "description": "Lidera la estrategia, planificación y performance de los canales sociales de nuestros clientes. Convierte insights en calendarios de contenido que hacen crecer comunidades y generan resultados medibles."
+            },
+            "community-manager": {
+                "title": "COMMUNITY MANAGER",
+                "type": "Tiempo completo / Medio tiempo",
+                "location": "Híbrido",
+                "description": "Sé la voz de las marcas en redes sociales. Conversa, modera y genera vínculos genuinos que fortalecen la relación entre las marcas y sus audiencias."
+            },
+            "content-creation-intern-chile": {
+                "title": "PRÁCTICA CREACIÓN DE CONTENIDO CHILE",
+                "type": "Práctica",
+                "location": "Híbrido",
+                "description": "Da tus primeros pasos creando contenido para marcas reales en el mercado chileno. Aprende junto a nuestro equipo creativo produciendo piezas visuales y escritas para campañas reales."
+            },
             "account-executive": {
                 "title": "GESTIÓN DE CUENTAS",
                 "type": "Tiempo completo",


### PR DESCRIPTION
## Summary
Added three new job listings to the careers page with full internationalization support for English and Spanish locales.

## Key Changes
- **Job Data** (`src/data/jobsData.ts`):
  - Added "Social Media Manager" (Full-time/Part-time, Hybrid)
  - Added "Community Manager" (Full-time/Part-time, Hybrid)
  - Added "Content Creation Internship Chile" (Internship, Hybrid)
  - Each listing includes application URL pointing to Google Forms

- **English Translations** (`src/locales/en/translation.json`):
  - Added three job listing entries under `jobs.listings` with English titles and descriptions

- **Spanish Translations** (`src/locales/es/translation.json`):
  - Added three job listing entries under `jobs.listings` with Spanish titles and descriptions
  - "Content Creation Internship Chile" translated as "PRÁCTICA CREACIÓN DE CONTENIDO CHILE"

## Implementation Details
- All three jobs follow the existing `Job` interface structure with `id`, `title`, `type`, `location`, `description`, and `applyUrl` fields
- Listings are positioned at the top of the jobs array for visibility
- Spanish translations maintain consistency with existing terminology (e.g., "Híbrido" for Hybrid, "Práctica" for Internship)
- Each job has a unique Google Forms application link

https://claude.ai/code/session_01HDPvZ3zJ8EoMR8eSgW3WGv